### PR TITLE
fix: add model provider tag + correct session display (closes #28)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -407,6 +407,7 @@
       <div class="card">
         <h3>Model</h3>
         <div class="value small" id="model">—</div>
+        <div class="sub" id="model-provider"></div>
       </div>
       
       <div class="card">
@@ -772,7 +773,20 @@
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
         
-        setText('model', data.model);
+        // Display model with provider tag
+        if (data.model) {
+          // Strip routing provider prefix for display
+          // e.g., "openrouter/anthropic/claude-opus-4-6" → "anthropic/claude-opus-4-6"
+          let displayModel = data.model;
+          if (data.provider) {
+            const prefix = data.provider.toLowerCase() + '/';
+            if (data.model.startsWith(prefix)) {
+              displayModel = data.model.slice(prefix.length);
+            }
+          }
+          setText('model', displayModel);
+          setText('model-provider', data.provider ? 'via ' + data.provider : '');
+        }
         setText('compactions', data.compactions);
         setText('session', data.session);
         setText('context-percent', data.context?.percent);

--- a/scripts/update-dashboard.sh
+++ b/scripts/update-dashboard.sh
@@ -260,6 +260,40 @@ update_status() {
     local updated
     updated=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+    # Read model and agent name from openclaw.json (dynamic, not hardcoded)
+    local openclaw_config="${HOME}/.openclaw/openclaw.json"
+    local model_string="unknown"
+    local agent_name="nova"
+
+    if [ -f "$openclaw_config" ]; then
+        # Primary model: agents.defaults.model.primary or agents.defaults.model (string)
+        model_string=$(jq -r '
+            .agents.defaults.model.primary //
+            (if (.agents.defaults.model | type) == "string" then .agents.defaults.model else null end) //
+            "unknown"
+        ' "$openclaw_config" 2>/dev/null || echo "unknown")
+
+        # Agent name: first agent in list with id matching the primary, or the first one
+        # For NOVA, we look for the main agent identity
+        agent_name=$(jq -r '
+            (.agents.list[] | select(.id == "nova") | .id) //
+            (.agents.list[0].id) //
+            "main"
+        ' "$openclaw_config" 2>/dev/null || echo "nova")
+    fi
+
+    # Derive provider from model string prefix (e.g., "openrouter/anthropic/claude-opus-4-6")
+    local provider=""
+    if [[ "$model_string" == openrouter/* ]]; then
+        provider="OpenRouter"
+    elif [[ "$model_string" == anthropic/* ]]; then
+        provider="Anthropic"
+    elif [[ "$model_string" == openai/* ]]; then
+        provider="OpenAI"
+    elif [[ "$model_string" == google/* ]]; then
+        provider="Google"
+    fi
+
     cat > "$tmp_file" << EOF
 {
   "context": {
@@ -268,10 +302,11 @@ update_status() {
     "percent": 0
   },
   "compactions": $compactions,
-  "model": "anthropic/claude-opus-4-5",
+  "model": "$model_string",
+  "provider": $([ -n "$provider" ] && echo "\"$provider\"" || echo "null"),
   "lastCompaction": $last_compaction,
   "updated": "$updated",
-  "session": "agent:main:main",
+  "session": "agent:${agent_name}:main",
   "source": "cron"
 }
 EOF


### PR DESCRIPTION
## Changes

### Fix 1: Model provider tag
- `update_status()` now reads the model dynamically from `openclaw.json` instead of hardcoding `anthropic/claude-opus-4-5`
- Derives provider from model string prefix (openrouter/, anthropic/, etc.)
- Frontend strips the routing prefix for clean display (e.g., `anthropic/claude-opus-4-6` instead of `openrouter/anthropic/claude-opus-4-6`)
- Provider shown as 'via OpenRouter' sub-text on the Model card

### Fix 2: Session display
- Session now shows `agent:nova:main` (read from config) instead of hardcoded `agent:main:main`

Closes #28