### PR TITLE
feat: auto-update reports.json and show all report types

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,16 +606,34 @@
     <div class="section-title"><span>Reports</span><span class="timestamp" id="reports-updated"></span></div>
     <div class="grid">
       
-      <div class="card wide" id="digest-card" style="cursor: pointer; opacity: 0.5;" onclick="openReport('dailyDigest')">
+      <div class="card wide report-card" id="digest-card" style="cursor: pointer; opacity: 0.5;" onclick="openReport('dailyDigest')">
         <h3>📝 Daily Activity Digest</h3>
         <div class="value small" id="digest-date">—</div>
         <div class="sub">Tasks, tokens, and highlights</div>
       </div>
       
-      <div class="card wide" id="comms-card" style="cursor: pointer; opacity: 0.5;" onclick="openReport('commsDigest')">
+      <div class="card wide report-card" id="comms-card" style="cursor: pointer; opacity: 0.5;" onclick="openReport('commsDigest')">
         <h3>📬 Communications Digest</h3>
         <div class="value small" id="comms-date">—</div>
         <div class="sub">Email & social activity summary</div>
+      </div>
+
+      <div class="card wide report-card" id="devops-card" style="cursor: pointer; opacity: 0.5;" onclick="openReport('devopsReport')">
+        <h3>🔧 IT/DevOps Report</h3>
+        <div class="value small" id="devops-date">—</div>
+        <div class="sub">Infrastructure and operations</div>
+      </div>
+
+      <div class="card wide report-card" id="swe-card" style="cursor: pointer; opacity: 0.5;" onclick="openReport('sweReport')">
+        <h3>💻 Software Engineering Report</h3>
+        <div class="value small" id="swe-date">—</div>
+        <div class="sub">Code, PRs, and development progress</div>
+      </div>
+
+      <div class="card wide report-card" id="mind-card" style="cursor: pointer; opacity: 0.5;" onclick="openReport('mindReport')">
+        <h3>🧠 Mind Report</h3>
+        <div class="value small" id="mind-date">—</div>
+        <div class="sub">Cognitive metrics and memory health</div>
       </div>
     </div>
 
@@ -1124,26 +1142,28 @@
         const res = await fetch('reports.json?' + Date.now());
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         reportsData = await res.json();
-        
-        const digest = reportsData.reports?.dailyDigest;
-        
-        // Daily Digest
-        if (digest?.available && digest.date) {
-          setText('digest-date', digest.date);
-          document.getElementById('digest-card').style.opacity = '1';
-        } else {
-          setText('digest-date', 'Not available');
-          document.getElementById('digest-card').style.opacity = '0.5';
-        }
-        
-        // Communications Digest
-        const comms = reportsData.reports?.commsDigest;
-        if (comms?.available && comms.date) {
-          setText('comms-date', comms.date);
-          document.getElementById('comms-card').style.opacity = '1';
-        } else {
-          setText('comms-date', 'Not available');
-          document.getElementById('comms-card').style.opacity = '0.5';
+
+        // Map report keys to their card/date element IDs
+        const reportCards = {
+          dailyDigest:  { card: 'digest-card',  date: 'digest-date' },
+          commsDigest:  { card: 'comms-card',   date: 'comms-date' },
+          devopsReport: { card: 'devops-card',  date: 'devops-date' },
+          sweReport:    { card: 'swe-card',     date: 'swe-date' },
+          mindReport:   { card: 'mind-card',    date: 'mind-date' },
+        };
+
+        for (const [key, els] of Object.entries(reportCards)) {
+          const report = reportsData.reports?.[key];
+          const cardEl = document.getElementById(els.card);
+          if (!cardEl) continue;
+
+          if (report?.available && report.date) {
+            setText(els.date, report.date);
+            cardEl.style.opacity = '1';
+          } else {
+            setText(els.date, 'Not available');
+            cardEl.style.opacity = '0.5';
+          }
         }
         
         if (reportsData.updated) {

--- a/scripts/update-dashboard.sh
+++ b/scripts/update-dashboard.sh
@@ -839,6 +839,122 @@ EOF
 }
 
 # ====================
+# Section: Reports
+# ====================
+# Outputs: reports.json
+# Data sources:
+#   - ~/www/static/reports/ directory — scans for report files and latest-* symlinks
+#   - Report types: Daily Digest, Communications Digest, IT/DevOps, SWE, Mind
+# ====================
+update_reports() {
+    local out_file="${OUTPUT_DIR}/reports.json"
+    local tmp_file="${out_file}.tmp"
+    local reports_dir="${HOME}/www/static/reports"
+
+    if [ ! -d "$reports_dir" ]; then
+        echo "WARN: Reports directory $reports_dir does not exist; skipping reports.json update" >&2
+        return 0
+    fi
+
+    # Helper: find the most recent report file matching a glob pattern and extract its date.
+    # Args: $1 = file prefix (e.g., "NOVA_Comms_Digest")
+    # Outputs: "date|filename" or empty string if none found
+    _latest_report() {
+        local prefix="$1"
+        local latest_file
+        # Files are named <prefix>_YYYY-MM-DD.html — sort by name descending gives newest first
+        latest_file=$(ls -1 "${reports_dir}/${prefix}_"????-??-??.html 2>/dev/null | sort -r | head -1)
+        if [ -n "$latest_file" ]; then
+            local basename
+            basename=$(basename "$latest_file")
+            # Extract date from filename: everything after the last _ and before .html
+            local date_part
+            date_part=$(echo "$basename" | grep -oP '\d{4}-\d{2}-\d{2}(?=\.html$)')
+            echo "${date_part}|${basename}"
+        fi
+    }
+
+    # Build report entries
+    # Map: json_key|file_prefix|symlink_name|display_title
+    local report_defs=(
+        "dailyDigest|NOVA_Daily_Digest|latest-daily-digest.html|Daily Activity Digest"
+        "commsDigest|NOVA_Comms_Digest|latest-comms-digest.html|Communications Digest"
+        "devopsReport|NOVA_IT_DevOps_Report|latest-devops-report.html|IT/DevOps Report"
+        "sweReport|NOVA_SWE_Report|latest-swe-report.html|Software Engineering Report"
+        "mindReport|NOVA_Mind_Report|latest-mind-report.html|Mind Report"
+    )
+
+    # Start building JSON
+    local reports_obj="{}"
+
+    for def in "${report_defs[@]}"; do
+        IFS='|' read -r json_key file_prefix symlink_name title <<< "$def"
+
+        local result available="false" date="null" url="null"
+
+        result=$(_latest_report "$file_prefix")
+
+        if [ -n "$result" ]; then
+            local report_date report_filename
+            IFS='|' read -r report_date report_filename <<< "$result"
+
+            if [ -n "$report_date" ]; then
+                available="true"
+                date="\"$report_date\""
+
+                # Prefer the latest-* symlink URL if it exists; otherwise link directly to the file
+                if [ -L "${reports_dir}/${symlink_name}" ]; then
+                    url="\"/reports/${symlink_name}\""
+                else
+                    url="\"/reports/${report_filename}\""
+                fi
+            fi
+        else
+            # Also check for the legacy NOVA_IT_Report prefix (older devops reports)
+            if [ "$json_key" = "devopsReport" ]; then
+                result=$(_latest_report "NOVA_IT_Report")
+                if [ -n "$result" ]; then
+                    local report_date report_filename
+                    IFS='|' read -r report_date report_filename <<< "$result"
+                    if [ -n "$report_date" ]; then
+                        available="true"
+                        date="\"$report_date\""
+                        if [ -L "${reports_dir}/${symlink_name}" ]; then
+                            url="\"/reports/${symlink_name}\""
+                        else
+                            url="\"/reports/${report_filename}\""
+                        fi
+                    fi
+                fi
+            fi
+        fi
+
+        reports_obj=$(echo "$reports_obj" | jq \
+            --arg key "$json_key" \
+            --argjson available "$available" \
+            --argjson date "$date" \
+            --argjson url "$url" \
+            --arg title "$title" \
+            '. + {($key): {available: $available, date: $date, url: $url, title: $title}}')
+    done
+
+    # Write the final reports.json
+    jq -n \
+        --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --argjson reports "$reports_obj" \
+        '{updated: $updated, reports: $reports}' > "$tmp_file"
+
+    if ! jq . "$tmp_file" > /dev/null 2>&1; then
+        echo "ERROR: Generated invalid JSON for reports.json" >&2
+        rm -f "$tmp_file"
+        return 1
+    fi
+
+    mv "$tmp_file" "$out_file"
+    echo "reports.json updated at $(date)"
+}
+
+# ====================
 # Main: Run all sections
 # ====================
 # Each section is invoked in a subshell ( ... ) so that:
@@ -853,6 +969,7 @@ echo "=== Nova Dashboard Update: $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 ( update_status ) || echo "WARN: status.json update failed" >&2
 ( update_staff )  || echo "WARN: staff.json update failed" >&2
 ( update_postgres ) || echo "WARN: postgres.json update failed" >&2
+( update_reports ) || echo "WARN: reports.json update failed" >&2
 update_anthropic   # already handles its own errors internally
 
 echo "=== Dashboard update complete ==="


### PR DESCRIPTION
## Summary

Fixes #29 — Reports section cards now link to the most recent report with correct timestamps.

## Changes

### Backend (update-dashboard.sh)
- Added `update_reports` section that runs every 5 minutes with the other dashboard updates
- Scans `~/www/static/reports/` for the latest file of each report type by parsing dates from filenames
- Supports 5 report types: Daily Digest, Communications Digest, IT/DevOps, SWE, and Mind reports
- Handles legacy `NOVA_IT_Report` prefix for older devops reports
- Prefers `latest-*` symlinks for URLs when they exist
- Validates generated JSON before writing

### Frontend (index.html)
- Added 3 new report cards: IT/DevOps Report, Software Engineering Report, Mind Report
- Refactored `loadReports()` from hardcoded if/else blocks to a data-driven loop
- All cards correctly show availability status (opacity) and date from reports.json

## Testing
- Ran `update-dashboard.sh` end-to-end — reports.json correctly shows:
  - Comms Digest: 2026-04-17 ✅
  - DevOps Report: 2026-04-16 ✅  
  - SWE Report: 2026-04-16 ✅
  - Mind Report: 2026-04-16 ✅
  - Daily Digest: not available (none exist yet) ✅