### PR TITLE
feat: add Graybeard as peer agent on dashboard (closes #22)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1003,7 +1003,7 @@
               <div class="staff-avatar">NH</div>
               <div>
                 <div class="staff-name">Newhart</div>
-                <div class="staff-role">NHR Agent • Full Instance</div>
+                <div class="staff-role">Peer Agent • Full Instance</div>
               </div>
             </div>
             <div class="staff-meta">
@@ -1012,6 +1012,36 @@
                 ${isOnline ? 'Online' : 'Offline'}
               </div>
               <div class="model">:${nh.port || '—'}</div>
+            </div>
+          `;
+          grid.appendChild(card);
+        }
+        
+        // Render Graybeard (peer agent) second if present
+        if (data.graybeard) {
+          const gb = data.graybeard;
+          const gbStatus = normalizeStatus(gb.status);
+          const isOnline = gbStatus === 'online';
+          
+          const card = document.createElement('a');
+          card.className = 'staff-card primary';
+          card.href = gb.dashboardUrl || '#';
+          if (!gb.dashboardUrl) card.style.cursor = 'default';
+          
+          card.innerHTML = `
+            <div class="staff-header">
+              <div class="staff-avatar">GB</div>
+              <div>
+                <div class="staff-name">Graybeard</div>
+                <div class="staff-role">Peer Agent • Full Instance</div>
+              </div>
+            </div>
+            <div class="staff-meta">
+              <div class="staff-status">
+                <span class="dot ${isOnline ? 'online' : 'offline'}"></span>
+                ${isOnline ? 'Online' : 'Offline'}
+              </div>
+              <div class="model">:${gb.port || '—'}</div>
             </div>
           `;
           grid.appendChild(card);

--- a/index.html
+++ b/index.html
@@ -973,23 +973,38 @@
         if (!grid) return;
         grid.innerHTML = '';
         
-        // Render Newhart (graduated instance) first if present
-        if (data.newhart) {
-          const nh = data.newhart;
-          const nhStatus = normalizeStatus(nh.status);
-          const isOnline = nhStatus === 'online';
+        // Render peer agents (full instances with their own gateways)
+        // Support both new `peers` object and legacy `newhart` key
+        const peers = data.peers || {};
+        
+        // If no `peers` key, fall back to legacy `newhart` structure
+        if (Object.keys(peers).length === 0 && data.newhart) {
+          peers.newhart = { ...data.newhart, role: 'NHR Agent' };
+        }
+        
+        // Peer display config: initials, colors, labels
+        const peerMeta = {
+          newhart:   { initials: 'NH', label: 'NHR Agent • Full Instance', gradient: 'linear-gradient(135deg, #00d9ff, #a855f7)' },
+          graybeard: { initials: 'GB', label: 'IT/SysAdmin • Full Instance', gradient: 'linear-gradient(135deg, #6b7280, #d1d5db)' }
+        };
+        
+        Object.entries(peers).forEach(([name, peer]) => {
+          const peerStatus = normalizeStatus(peer.status);
+          const isOnline = peerStatus === 'online';
+          const meta = peerMeta[name] || { initials: name.slice(0, 2).toUpperCase(), label: (peer.role || 'Peer Agent') + ' • Full Instance', gradient: 'linear-gradient(135deg, #00d9ff, #a855f7)' };
+          const displayName = name.charAt(0).toUpperCase() + name.slice(1);
           
           const card = document.createElement('a');
           card.className = 'staff-card primary';
-          card.href = nh.dashboardUrl || '#';
-          if (!nh.dashboardUrl) card.style.cursor = 'default';
+          card.href = peer.dashboardUrl || '#';
+          if (!peer.dashboardUrl) card.style.cursor = 'default';
           
           card.innerHTML = `
             <div class="staff-header">
-              <div class="staff-avatar">NH</div>
+              <div class="staff-avatar" style="background: ${meta.gradient}">${meta.initials}</div>
               <div>
-                <div class="staff-name">Newhart</div>
-                <div class="staff-role">NHR Agent • Full Instance</div>
+                <div class="staff-name">${displayName}</div>
+                <div class="staff-role">${meta.label}</div>
               </div>
             </div>
             <div class="staff-meta">
@@ -997,17 +1012,17 @@
                 <span class="dot ${isOnline ? 'online' : 'offline'}"></span>
                 ${isOnline ? 'Online' : 'Offline'}
               </div>
-              <div class="model">:${nh.port || '—'}</div>
+              <div class="model">:${peer.port || '—'}</div>
             </div>
           `;
           grid.appendChild(card);
-        }
+        });
         
         // Render sub-agents
         const agents = data.agents || [];
         agents.forEach(agent => {
-          // Skip nova-main (that's me) and nhr-agent (Newhart shown above)
-          if (agent.name === 'nova-main' || agent.name === 'nhr-agent') return;
+          // Skip primary agent and peer agents (shown separately above)
+          if (agent.name === 'nova-main' || agent.name === 'nhr-agent' || agent.name === 'graybeard') return;
           
           const card = document.createElement('a');
           card.className = 'staff-card';

--- a/index.html
+++ b/index.html
@@ -985,7 +985,7 @@
         // Peer display config: initials, colors, labels
         const peerMeta = {
           newhart:   { initials: 'NH', label: 'NHR Agent • Full Instance', gradient: 'linear-gradient(135deg, #00d9ff, #a855f7)' },
-          graybeard: { initials: 'GB', label: 'IT/SysAdmin • Full Instance', gradient: 'linear-gradient(135deg, #6b7280, #d1d5db)' }
+          graybeard: { initials: 'GB', label: 'Peer Agent • Full Instance', gradient: 'linear-gradient(135deg, #6b7280, #d1d5db)' }
         };
         
         Object.entries(peers).forEach(([name, peer]) => {

--- a/scripts/update-dashboard.sh
+++ b/scripts/update-dashboard.sh
@@ -332,17 +332,17 @@ update_staff() {
     # Peer agents run their own OpenClaw gateways on dedicated ports.
     # Try HTTP health check first; fall back to process detection if the gateway isn't responding.
 
-    # Newhart — graduated NOVA instance on port 18800
+    # Newhart — graduated NOVA instance on port 18700
     local newhart_status="offline"
-    if curl -s --max-time 2 "http://localhost:18800/health" > /dev/null 2>&1; then
+    if curl -s --max-time 2 "http://localhost:18700/health" > /dev/null 2>&1; then
         newhart_status="online"
     elif pgrep -u newhart -f "openclaw" > /dev/null 2>&1; then
         newhart_status="online"
     fi
 
-    # Graybeard — IT/SysAdmin peer agent on port 18802
+    # Graybeard — peer agent on port 18800
     local graybeard_status="offline"
-    if curl -s --max-time 2 "http://localhost:18802/health" > /dev/null 2>&1; then
+    if curl -s --max-time 2 "http://localhost:18800/health" > /dev/null 2>&1; then
         graybeard_status="online"
     elif pgrep -u graybeard -f "openclaw" > /dev/null 2>&1; then
         graybeard_status="online"
@@ -387,26 +387,16 @@ FROM (
     cat > "$tmp_file" << EOF
 {
   "updated": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "peers": {
-    "newhart": {
-      "status": "$newhart_status",
-      "port": 18800,
-      "user": "newhart",
-      "role": "NHR Agent",
-      "dashboardUrl": null
-    },
-    "graybeard": {
-      "status": "$graybeard_status",
-      "port": 18802,
-      "user": "graybeard",
-      "role": "IT/SysAdmin",
-      "dashboardUrl": null
-    }
-  },
   "newhart": {
     "status": "$newhart_status",
-    "port": 18800,
+    "port": 18700,
     "user": "newhart",
+    "dashboardUrl": null
+  },
+  "graybeard": {
+    "status": "$graybeard_status",
+    "port": 18800,
+    "user": "graybeard",
     "dashboardUrl": null
   },
   "agents": $agents_json,

--- a/scripts/update-dashboard.sh
+++ b/scripts/update-dashboard.sh
@@ -329,13 +329,23 @@ update_staff() {
     local tmp_file="${out_file}.tmp"
     local db_name
 
-    # Newhart is a graduated NOVA instance running its own OpenClaw gateway on port 18800.
+    # Peer agents run their own OpenClaw gateways on dedicated ports.
     # Try HTTP health check first; fall back to process detection if the gateway isn't responding.
+
+    # Newhart — graduated NOVA instance on port 18800
     local newhart_status="offline"
     if curl -s --max-time 2 "http://localhost:18800/health" > /dev/null 2>&1; then
         newhart_status="online"
     elif pgrep -u newhart -f "openclaw" > /dev/null 2>&1; then
         newhart_status="online"
+    fi
+
+    # Graybeard — IT/SysAdmin peer agent on port 18802
+    local graybeard_status="offline"
+    if curl -s --max-time 2 "http://localhost:18802/health" > /dev/null 2>&1; then
+        graybeard_status="online"
+    elif pgrep -u graybeard -f "openclaw" > /dev/null 2>&1; then
+        graybeard_status="online"
     fi
 
     # Query agents from database
@@ -377,6 +387,22 @@ FROM (
     cat > "$tmp_file" << EOF
 {
   "updated": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "peers": {
+    "newhart": {
+      "status": "$newhart_status",
+      "port": 18800,
+      "user": "newhart",
+      "role": "NHR Agent",
+      "dashboardUrl": null
+    },
+    "graybeard": {
+      "status": "$graybeard_status",
+      "port": 18802,
+      "user": "graybeard",
+      "role": "IT/SysAdmin",
+      "dashboardUrl": null
+    }
+  },
   "newhart": {
     "status": "$newhart_status",
     "port": 18800,


### PR DESCRIPTION
Adds Graybeard as a peer agent alongside Newhart on the dashboard. Fixes Newhart port from 18800 to 18700 (port 18800 is now Graybeard's gateway).